### PR TITLE
fix: Allow multiple usages of BuilderContent component

### DIFF
--- a/src/runtime/components/BuilderContent.vue
+++ b/src/runtime/components/BuilderContent.vue
@@ -43,11 +43,15 @@ const {
   }
 } = useRuntimeConfig().public.builderIO
 
-const { data } = await useAsyncData(async () => await fetchBuilderProps({
-  model: props.model || defaultModel,
+const model = props.model || defaultModel
+const urlPath = props.path || useRoute().path
+const asyncDataKey = `builder-content-${model}-${urlPath}`
+  
+const { data } = await useAsyncData(asyncDataKey, async () => await fetchBuilderProps({
+  model,
   apiKey,
   userAttributes: {
-    urlPath: props.path || useRoute().path
+    urlPath
   },
   ...props.extra,
 }))


### PR DESCRIPTION
It wasn't possible to use multiple instances of the `BuilderContent` component, because no key was provided for `useAsyncData`, so only the first `BuilderContent` instance was fetching the data from the builder.io api, which led to the content being rendered twice.
My use case is that I want to have a `BuilderContent` for the normal page content and an announcement bar section, which is a different model.